### PR TITLE
Fix: Update GitHub workflow to build and upload binary

### DIFF
--- a/.github/workflows/cmake-ubuntu.yml
+++ b/.github/workflows/cmake-ubuntu.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install X11 development libraries
+      run: sudo apt-get update && sudo apt-get install -y xorg-dev
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
@@ -30,6 +33,12 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Upload xskat binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: xskat-binary
+        path: ${{github.workspace}}/build/xskat
 
     - name: Test
       working-directory: ${{github.workspace}}/build


### PR DESCRIPTION
The GitHub workflow was updated to address issues with the binary build:

1. Install X11 dependencies: I added a step to install 'xorg-dev' using apt-get, as X11 is a required dependency for building the xskat project. This ensures the build environment has the necessary libraries.

2. Upload compiled binary: I added a step using 'actions/upload-artifact@v3' to upload the compiled 'xskat' executable as an artifact named 'xskat-binary'. This makes the built binary easily accessible after each successful workflow run.

The binary name 'xskat' and its location in the 'build' directory were confirmed from the CMakeLists.txt file.