### PR TITLE
Fix: Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/cmake-ubuntu.yml
+++ b/.github/workflows/cmake-ubuntu.yml
@@ -35,7 +35,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Upload xskat binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: xskat-binary
         path: ${{github.workspace}}/build/xskat


### PR DESCRIPTION
I've updated the GitHub Actions workflow to use `actions/upload-artifact@v4` as `v3` is deprecated and will stop working in January 2025.